### PR TITLE
Fix offset caused by parent element

### DIFF
--- a/cjs/index.js
+++ b/cjs/index.js
@@ -245,7 +245,12 @@ if (!customElements.get(TAG)) {
     for (const {target} of entries) {
       const pre = targets.get(target);
       const {border, font, letterSpacing, lineHeight, padding, wordSpacing} = getComputedStyle(target);
-      const {top, left, width, height} = target.getBoundingClientRect();
+      let {top, left, width, height} = target.getBoundingClientRect();
+      if (target.offsetParent){
+        const parentRect = target.offsetParent.getBoundingClientRect();
+        top = top - parentRect.top;
+        left = left - parentRect.left;
+      }
       pre.style.cssText = `
         position: absolute;
         overflow: auto;

--- a/esm/index.js
+++ b/esm/index.js
@@ -244,7 +244,12 @@ if (!customElements.get(TAG)) {
     for (const {target} of entries) {
       const pre = targets.get(target);
       const {border, font, letterSpacing, lineHeight, padding, wordSpacing} = getComputedStyle(target);
-      const {top, left, width, height} = target.getBoundingClientRect();
+      let {top, left, width, height} = target.getBoundingClientRect();
+      if (target.offsetParent){
+        const parentRect = target.offsetParent.getBoundingClientRect();
+        top = top - parentRect.top;
+        left = left - parentRect.left;
+      }
       pre.style.cssText = `
         position: absolute;
         overflow: auto;


### PR DESCRIPTION
### Fix offset caused by parent element
 
Steps to reproduce:
1) add bootstrap css `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">`
2) add header tag `<header>` 
3) put `<textarea>` into `<div class="card">` with class card

result has offset between `<textarea>` and `<pre>`
![2024-09-12 094904](https://github.com/user-attachments/assets/86203aed-24ac-47c4-915c-1502cafa0d97)

Fix by delta between top and left target and target.offsetParent 

```
<!doctype html>
<meta name="viewport" content="width=device-width,initial-scale=1.0">
<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
<style>
textarea[is="highlighted-code"] { padding: 8px; }
</style>
<script type="module">
(async ({chrome, netscape}) => {

  // add Safari polyfill if needed
  if (!chrome && !netscape)
    await import('https://unpkg.com/@ungap/custom-elements');

  const {default: HighlightedCode} =
    await import('https://unpkg.com/highlighted-code');

  // bootstrap a theme through one of these names
  // https://github.com/highlightjs/highlight.js/tree/main/src/styles
  HighlightedCode.useTheme('github-dark');
})(self);
</script>
<header class="py-3 mb-3 bg-dark">
    <nav class="navbar">
        <div class="container">
            <span class="navbar-brand text-light">
              Header
            </span>
        </div>
    </nav>
</header>
<div class="card">
  <textarea is="highlighted-code"
          cols="80" rows="12"
          language="javascript" tab-size="2" auto-height>
(async ({chrome, netscape}) => {

  // add Safari polyfill if needed
  if (!chrome && !netscape)
    await import('https://unpkg.com/@ungap/custom-elements');

  const {default: HighlightedCode} = await import('https://unpkg.com/highlighted-code');

  // bootstrap a theme through one of these names
  // https://github.com/highlightjs/highlight.js/tree/main/src/styles
  HighlightedCode.useTheme('github-dark');
})(self);
  </textarea>
</div>
```
